### PR TITLE
Adds plasma vents

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -250,3 +250,48 @@
 		colorindex = 0
 	icon_state = "mobcap[colorindex]"
 	update_icon()
+
+/obj/effect/vent
+	name = "weed vent"  // You did something stupid, spawning a parent class
+						// suffer the dank memes
+	desc = "This vent appears to be emitting a dank smoke. 420 blazeit ayylmao"
+	icon = 'icons/effects/effects.dmi'
+	icon_state = "exhaust"
+	var/moles_left = 10000 // haha what am I doing
+	var/leak_rate = 0.01
+	var/gas_type = "dank kush"
+	anchored = 1
+
+/obj/effect/vent/New()
+	..()
+	processing_objects.Add(src)
+
+/obj/effect/vent/process()
+	var/gas_to_eject = leak_rate * moles_left
+	moles_left -= gas_to_eject
+	switch(gas_type)
+		if("plasma")
+			var/turf/simulated/T = get_turf(src)
+			T.atmos_spawn_air(SPAWN_TOXINS|SPAWN_20C,gas_to_eject)
+		if("dank kush")
+			var/datum/reagents/R = new/datum/reagents(50)
+			R.my_atom = src
+			R.add_reagent("space drugs", 50)
+			var/datum/effect/system/chem_smoke_spread/smoke = new
+			smoke.set_up(R, rand(1, 2), 0, src, 0, silent = 1)
+			smoke.start(3)
+			qdel(R)
+	if(moles_left < 0)
+		become_empty()
+
+/obj/effect/vent/proc/become_empty()
+	processing_objects.Remove(src)
+	name = "depleted gas vent"
+	desc = "This fissure seems to have stopped leaking gas."
+	moles_left = 0
+
+
+/obj/effect/vent/plasma
+	name = "plasma vent"
+	gas_type = "plasma"
+	desc = "This opening in the ground appears to be emitting a purple gas!"

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -276,7 +276,7 @@
 		if("dank kush")
 			var/datum/reagents/R = new/datum/reagents(50)
 			R.my_atom = src
-			R.add_reagent("space drugs", 50)
+			R.add_reagent("space_drugs", 50)
 			var/datum/effect/system/chem_smoke_spread/smoke = new
 			smoke.set_up(R, rand(1, 2), 0, src, 0, silent = 1)
 			smoke.start(3)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -110,7 +110,7 @@ var/global/list/rockTurfEdgeCache = list(
 		"Uranium" = 5, "Diamond" = 1, "Gold" = 10,
 		"Silver" = 12, "Plasma" = 20, "Iron" = 40,
 		"Gibtonite" = 4, "Cave" = 2, "BScrystal" = 1,
-		/*, "Adamantine" =5*/)
+		"PlasmaVent" = 30)
 		//Currently, Adamantine won't spawn as it has no uses. -Durandan
 	var/mineralChance = 13
 
@@ -144,6 +144,8 @@ var/global/list/rockTurfEdgeCache = list(
 					M = new/turf/simulated/mineral/mime(src)
 				if("BScrystal")
 					M = new/turf/simulated/mineral/bscrystal(src)
+				if("PlasmaVent")
+					M = new/turf/simulated/mineral/vent/plasma(src)
 			if(M)
 				M.mineralAmt = rand(1, 5)
 				src = M
@@ -157,7 +159,7 @@ var/global/list/rockTurfEdgeCache = list(
 	mineralSpawnChanceList = list(
 		"Uranium" = 35, "Diamond" = 30,
 		"Gold" = 45, "Silver" = 50, "Plasma" = 50,
-		"BScrystal" = 20)
+		"BScrystal" = 20, "PlasmaVent" = 25)
 
 
 /turf/simulated/mineral/random/high_chance_clown
@@ -177,7 +179,7 @@ var/global/list/rockTurfEdgeCache = list(
 	mineralSpawnChanceList = list(
 		"Uranium" = 2, "Diamond" = 1, "Gold" = 4,
 		"Silver" = 6, "Plasma" = 15, "Iron" = 40,
-		"Gibtonite" = 2, "BScrystal" = 1)
+		"Gibtonite" = 2, "BScrystal" = 1, "PlasmaVent" = 30)
 
 /turf/simulated/mineral/random/low_chance/New()
 	icon_state = "rock"
@@ -364,6 +366,26 @@ var/global/list/rockTurfEdgeCache = list(
 	var/stage = 0
 
 ////////////////////////////////End Gibtonite
+
+/turf/simulated/mineral/vent
+	name = "gas pocket"
+	spreadChance = 10
+	spread = 1
+	hidden = 1
+	var/vent_type = /obj/effect/vent
+
+/turf/simulated/mineral/vent/gets_drilled()
+	var/turf/simulated/floor/plating/airless/asteroid/N = ChangeTurf(/turf/simulated/floor/plating/airless/asteroid)
+	playsound(src, 'sound/effects/break_stone.ogg', 50, 1) //beautiful destruction
+	N.fullUpdateMineralOverlays()
+	new vent_type(N)
+
+/turf/simulated/mineral/vent/plasma
+	name = "gaseous plasma pocket"
+	vent_type = /obj/effect/vent/plasma
+
+
+
 
 /turf/simulated/mineral/attackby(var/obj/item/weapon/pickaxe/P as obj, mob/user as mob, params)
 

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -369,16 +369,18 @@ var/global/list/rockTurfEdgeCache = list(
 
 /turf/simulated/mineral/vent
 	name = "gas pocket"
+	scan_state = "rock_Clown"
 	spreadChance = 10
 	spread = 1
 	hidden = 1
 	var/vent_type = /obj/effect/vent
 
 /turf/simulated/mineral/vent/gets_drilled()
+	var/stored_vent_type = vent_type
 	var/turf/simulated/floor/plating/airless/asteroid/N = ChangeTurf(/turf/simulated/floor/plating/airless/asteroid)
 	playsound(src, 'sound/effects/break_stone.ogg', 50, 1) //beautiful destruction
 	N.fullUpdateMineralOverlays()
-	new vent_type(N)
+	new stored_vent_type(N)
 
 /turf/simulated/mineral/vent/plasma
 	name = "gaseous plasma pocket"


### PR DESCRIPTION
These are tiles that, when mined, create an effect that continually spawns plasma.
The numbers are currently ridiculous and probably not viable at the moment.
The intent is for this to be a fuel source atmos can harvest by setting up gas collection structures near - giving them active work to perform throughout the shift.